### PR TITLE
Fix CI checks on main

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -33,4 +33,4 @@ jobs:
           cache: pip
       - uses: pre-commit/action@v3.0.0
         env:
-          SKIP: no-commit-to-branch  # only for local development
+          SKIP: no-commit-to-branch # only for local development

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,3 +32,5 @@ jobs:
           python-version: "3.10"
           cache: pip
       - uses: pre-commit/action@v3.0.0
+        env:
+          SKIP: no-commit-to-branch  # only for local development


### PR DESCRIPTION
See https://pre-commit.com/#temporarily-disabling-hooks

> Not all hooks are perfect so sometimes you may need to skip execution of one or more hooks. pre-commit solves this by querying a `SKIP` environment variable. The `SKIP` environment variable is a comma separated list of hook ids.

Fixes #18